### PR TITLE
Reset collector field after closing the modal

### DIFF
--- a/src/modals/Transfer.js
+++ b/src/modals/Transfer.js
@@ -16,13 +16,15 @@ function Transfer(props) {
 
     const [loading, setLoading] = useState(false);
 
-    const [transfer, setTransfer] = useState({
+    const transferInitialState = {
         check: false,
         fees: 0,
         amount: 0,
         address: '',
         collector: ''
-    });
+    }
+
+    const [transfer, setTransfer] = useState(transferInitialState);
 
     async function pasteRecipientAddress() {
         setLoading(true);
@@ -100,10 +102,7 @@ function Transfer(props) {
         var instance = M.Modal.getInstance($('#transfer-modal'));
         instance.close();
         setTransfer({
-            check: false,
-            fees: 0,
-            amount: 0,
-            address: ''
+            ...transferInitialState
         });
     }
 


### PR DESCRIPTION
This change is required to avoid the field showing the value while the state doesn't reflect the change when the modal is opened after the first time.