### PR TITLE
Add the 'estimate' button on transfer modal plus further UI fixes

### DIFF
--- a/src/Utils.js
+++ b/src/Utils.js
@@ -88,8 +88,13 @@ class Utils {
 }
 
 const ESTIMATED_GAS_CORRECTION_FACTOR = 1.0;
+// When estimating the gas an internal call is going to spend, we need to subtract some gas inherent to send the parameters to the blockchain
 const INTERNAL_TRANSACTION_ESTIMATE_CORRECTION = 20000;
+// extracted from rif-relay-common/ContractInteractor
 async function estimateDestinationContractCallGas(transactionDetails, addCushion = true) {
+    // For relay calls, transactionDetails.gas is only the portion of gas sent to the destination contract, the tokenPayment
+    // Part is done before, by the SmartWallet
+
     const estimated = await window.web3.eth.estimateGas({
         from: transactionDetails.from,
         to: transactionDetails.to,
@@ -100,6 +105,13 @@ async function estimateDestinationContractCallGas(transactionDetails, addCushion
         estimated > INTERNAL_TRANSACTION_ESTIMATE_CORRECTION
             ? estimated - INTERNAL_TRANSACTION_ESTIMATE_CORRECTION
             : estimated;
+
+    // The INTERNAL_TRANSACTION_ESTIMATE_CORRECTION is substracted because the estimation is done using web3.eth.estimateGas which
+    // estimates the call as if it where an external call, and in our case it will be called internally (it's not the same cost).
+    // Because of this, the estimated maxPossibleGas in the server (which estimates the whole transaction) might not be enough to successfully pass
+    // the following verification made in the SmartWallet:
+    // require(gasleft() > req.gas, "Not enough gas left"). This is done right before calling the destination internally
+
     if (addCushion) {
         internalCallCost =
             internalCallCost * ESTIMATED_GAS_CORRECTION_FACTOR;

--- a/src/modals/Deploy.js
+++ b/src/modals/Deploy.js
@@ -21,9 +21,10 @@ function Deploy(props) {
         relayGas: 0
     });
     const [loading, setLoading] = useState(false);
+    const [estimateLoading, setEstimateLoading] = useState(false);
 
     async function handleEstimateDeploySmartWalletButtonClick() {
-        setLoading(true);
+        setEstimateLoading(true);
         try {
             const estimate = await provider.estimateMaxPossibleRelayGas(
                 currentSmartWallet
@@ -52,7 +53,7 @@ function Deploy(props) {
             alert(error.message);
             console.error(error);
         }
-        setLoading(false);
+        setEstimateLoading(false);
     }
 
     async function getReceipt(transactionHash) {
@@ -165,8 +166,8 @@ function Deploy(props) {
                 </div>
             </div>
             <div className="modal-footer">
-                <a href="#!" id="deploy-smart-wallet-estimate" className={`waves-effect waves-green btn-flat ${ loading? 'disabled' : ''}`} onClick={handleEstimateDeploySmartWalletButtonClick} >
-                    Estimate <img alt="loading" className={`loading ${ !loading? 'hide' : ''}`} src="images/loading.gif"/>
+                <a href="#!" id="deploy-smart-wallet-estimate" className={`waves-effect waves-green btn-flat ${ estimateLoading? 'disabled' : ''}`} onClick={handleEstimateDeploySmartWalletButtonClick} >
+                    Estimate <img alt="loading" className={`loading ${ !estimateLoading? 'hide' : ''}`} src="images/loading.gif"/>
                 </a>
                 <a onClick={handleDeploySmartWalletButtonClick} href="#!" className={`waves-effect waves-green btn-flat ${ loading? 'disabled' : ''}`}>
                     Deploy <img alt="loading" className={`loading ${ !loading? 'hide' : ''}`} src="images/loading.gif"/>

--- a/src/modals/Execute.js
+++ b/src/modals/Execute.js
@@ -33,10 +33,11 @@ function Execute(props) {
         function: '',
         fees: ''
     });
-    const [loading, setLoading] = useState(false);
+    const [executeLoading, setExecuteLoading] = useState(false);
+    const [estimateLoading, setEstimateLoading] = useState(false);
 
     async function handleExecuteSmartWalletButtonClick() {
-        setLoading(true);
+        setExecuteLoading(true);
         try {
             const funcData = calculateAbiEncodedFunction();
             const destinationContract = execute.address;
@@ -54,26 +55,27 @@ function Execute(props) {
                     address: swAddress
                 }, fees);
 
-                console.log('data: ', transaction)
-                console.log(`Your TxHash is ${transaction.blockHash}`)
+                console.log('Transaction ', transaction)
+                console.log(`Transaction hash: ${transaction.blockHash}`)
 
                 const logs = abiDecoder.decodeLogs(transaction.logs)
 
-                console.log("Your logs are: ", logs)
+                console.log("Transaction logs: ", logs)
 
                 const sampleRecipientEmitted = logs.find((e) => e != null && e.name === 'TransactionRelayed')
                 console.log(sampleRecipientEmitted)
                 if (execute.show) {
-                    setResults(transaction);
+                    setResults(JSON.stringify(transaction));
                 } else {
                     setUpdateInfo(true);
+                    close();
                 }
             }
         } catch (error) {
             alert(error.message);
             console.error(error)
         }
-        setLoading(false);
+        setExecuteLoading(false);
     }
     async function relayTransactionDirectExecution(toAddress, swAddress, abiEncodedTx) {
         const swContract = new web3.eth.Contract(IForwarder.abi, swAddress)
@@ -106,7 +108,7 @@ function Execute(props) {
     }
 
     async function handleEstimateSmartWalletButtonClick() {
-        setLoading(true);
+        setEstimateLoading(true);
         try {
             const isUnitRBTC = execute.check;
 
@@ -173,7 +175,7 @@ function Execute(props) {
             alert(error.message);
             console.error(error)
         }
-        setLoading(false);
+        setEstimateLoading(false);
     }
 
     function calculateAbiEncodedFunction() {
@@ -208,12 +210,12 @@ function Execute(props) {
     }
 
     async function pasteRecipientAddress() {
-        setLoading(true);
+        setExecuteLoading(true);
         const address = await navigator.clipboard.readText();
         if (Utils.checkAddress(address.toLowerCase())) {
             changeValue({ currentTarget: { value: address } }, 'address');
         }
-        setLoading(false);
+        setExecuteLoading(false);
     }
 
     async function estimateDirectExecution(swAddress, toAddress, abiEncodedTx) {
@@ -297,7 +299,7 @@ function Execute(props) {
                                 </label>
                             </div>
                         </div>
-                        <div className={`row mb-0 ${execute.show ? 'hide' : ''}`} id="execute-result-row">
+                        <div className={`row mb-0 ${execute.show && results ? '' : 'hide'}`} id="execute-result-row">
                             <div className="input-field col s12">
                                 <span id="execute-result" style={{ 'wordBreak': 'break-all', 'width': 'inherit' }}>{results}</span>
                             </div>
@@ -306,12 +308,12 @@ function Execute(props) {
                 </div>
             </div>
             <div className="modal-footer">
-                <a href="#!" id="execute-smart-wallet" className={`waves-effect waves-green btn-flat  ${loading ? 'disabled' : ''}`} onClick={() => {
+                <a href="#!" id="execute-smart-wallet" className={`waves-effect waves-green btn-flat  ${executeLoading ? 'disabled' : ''}`} onClick={() => {
                     handleExecuteSmartWalletButtonClick()
-                }}>Execute <img alt="loading" className={`loading ${!loading ? 'hide' : ''}`} src="images/loading.gif" /></a>
-                <a href="#!" id="execute-smart-wallet-estimate" className={`waves-effect waves-green btn-flat  ${loading ? 'disabled' : ''}`} onClick={() => {
+                }}>Execute <img alt="loading" className={`loading ${!executeLoading ? 'hide' : ''}`} src="images/loading.gif" /></a>
+                <a href="#!" id="execute-smart-wallet-estimate" className={`waves-effect waves-green btn-flat  ${estimateLoading ? 'disabled' : ''}`} onClick={() => {
                     handleEstimateSmartWalletButtonClick()
-                }}>Estimate <img alt="loading" className={`loading ${!loading ? 'hide' : ''}`} src="images/loading.gif" /></a>
+                }}>Estimate <img alt="loading" className={`loading ${!estimateLoading ? 'hide' : ''}`} src="images/loading.gif" /></a>
                 <a href="#!" id="execute-smart-wallet-cancel" className="waves-effect waves-green btn-flat" onClick={() =>{ close()}}>Cancel</a>
             </div>
         </div>

--- a/src/modals/Transfer.js
+++ b/src/modals/Transfer.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import Utils from '../Utils';
+import { toBN } from 'web3-utils';
+import Utils, { estimateMaxPossibleRelayGas, TRIF_PRICE } from '../Utils';
 import './Transfer.css';
 
 //import { useState } from 'react';
@@ -15,6 +16,7 @@ function Transfer(props) {
     } = props;
 
     const [loading, setLoading] = useState(false);
+    const [estimateLoading, setEstimateLoading] = useState(false);
 
     const [transfer, setTransfer] = useState({
         check: false,
@@ -34,7 +36,11 @@ function Transfer(props) {
 
     function changeValue(event, prop) {
         let obj = Object.assign({}, transfer);
-        obj[prop] = event.currentTarget.value;
+        if (event.currentTarget.type === 'checkbox') {
+            obj[prop] = event.currentTarget.checked;
+        } else {
+            obj[prop] = event.currentTarget.value;
+        }
         setTransfer(obj)
     }
 
@@ -54,7 +60,7 @@ function Transfer(props) {
             const encodedAbi = (await Utils.getTokenContract()).methods
                 .transfer(transfer.address, await Utils.toWei(amount)).encodeABI();
 
-            const txDetials = await provider.relayTransaction(
+            const txDetails = await provider.relayTransaction(
                 {
                     to: transfer.address
                     , data: encodedAbi
@@ -65,7 +71,7 @@ function Transfer(props) {
                 }
                 , fees
             );
-            console.log(txDetials);
+            console.log(txDetails);
             setUpdateInfo(true);
             close();
         } catch (error) {
@@ -103,6 +109,57 @@ function Transfer(props) {
             address: ''
         });
     }
+    
+      async function handleEstimateDeploySmartWalletButtonClick() {
+        setEstimateLoading(true);
+        const encodedTransferFunction = (await Utils.getTokenContract()).methods
+          .transfer(
+            transfer.address,
+            await Utils.toWei(transfer.amount.toString() || "0")
+          )
+          .encodeABI();
+        try {
+            const trxDetails = {
+                from: account,
+                to: process.env.REACT_APP_CONTRACTS_RIF_TOKEN,
+                value: "0",
+                relayHub: process.env.REACT_APP_CONTRACTS_RELAY_HUB,
+                callVerifier: process.env.REACT_APP_CONTRACTS_RELAY_VERIFIER,
+                callForwarder: currentSmartWallet.address,
+                data: encodedTransferFunction,
+                tokenContract: process.env.REACT_APP_CONTRACTS_RIF_TOKEN,
+                // value set just for the estimation; in the original dapp the estimation is performed using an eight of the user's token balance,
+                tokenAmount: window.web3.utils.toWei("1"),
+                onlyPreferredRelays: true,
+            };
+            const maxPossibleGasValue = await estimateMaxPossibleRelayGas(provider.relayProvider.relayClient, trxDetails);    
+            const gasPrice = toBN(
+                await provider.relayProvider.relayClient._calculateGasPrice()
+                );
+            console.log('maxPossibleGas, gasPrice', maxPossibleGasValue.toString(), gasPrice.toString());
+            const maxPossibleGas = toBN(maxPossibleGasValue);
+            const estimate = maxPossibleGas.mul(gasPrice);
+        
+            const costInRBTC = await Utils.fromWei(estimate.toString());
+            console.log("Cost in RBTC:", costInRBTC);
+
+            const costInTrif = parseFloat(costInRBTC) / TRIF_PRICE;
+            const tokenContract = await Utils.getTokenContract();
+            const ritTokenDecimals = await tokenContract.methods.decimals().call();
+            const costInTrifFixed = costInTrif.toFixed(ritTokenDecimals);
+            console.log("Cost in TRif: ", costInTrifFixed);
+
+            if (transfer.check === true) {
+                changeValue({ currentTarget: { value: costInRBTC } }, "fees");
+            } else {
+                changeValue({ currentTarget: { value: costInTrifFixed } }, "fees");
+            }
+        } catch (error) {
+          alert(error.message);
+          console.error(error);
+        }
+        setEstimateLoading(false);
+      }
 
     return (
         <div id="transfer-modal" className="modal">
@@ -127,7 +184,7 @@ function Transfer(props) {
                                 }} value={transfer.amount} />
                                 <label htmlFor="transfer-amount">Amount</label>
                             </div>
-                            <div className="switch col s4 hide" style={{ 'paddingTop': '2.5em' }}>
+                            <div className="switch col s4" style={{ 'paddingTop': '2.5em' }}>
                                 <label>
                                     tRIF
                                     <input type="checkbox" onChange={(event) => {
@@ -152,6 +209,9 @@ function Transfer(props) {
             <div className="modal-footer">
                 <a href="#!" onClick={handleTransferSmartWalletButtonClick} className={`waves-effect waves-green btn-flat ${ loading? 'disabled' : ''}`}>
                     Transfer <img alt="loading" className={`loading ${ !loading? 'hide' : ''}`} src="images/loading.gif"/>
+                </a>
+                <a href="#!" id="deploy-smart-wallet-estimate" className={`waves-effect waves-green btn-flat ${estimateLoading ? "disabled" : ""}`}onClick={handleEstimateDeploySmartWalletButtonClick}>
+                    Estimate<img alt="loading" className={`loading ${!estimateLoading ? "hide" : ""}`} src="images/loading.gif"/>
                 </a>
                 <a href="#!" className="waves-effect waves-green btn-flat" onClick={() =>{
                     close();

--- a/src/modals/Transfer.js
+++ b/src/modals/Transfer.js
@@ -108,17 +108,19 @@ function Transfer(props) {
             amount: 0,
             address: ''
         });
+        setEstimateLoading(false);
+        setLoading(false);
     }
     
-      async function handleEstimateDeploySmartWalletButtonClick() {
+      async function handleEstimateTransferButtonClick() {
         setEstimateLoading(true);
-        const encodedTransferFunction = (await Utils.getTokenContract()).methods
-          .transfer(
-            transfer.address,
-            await Utils.toWei(transfer.amount.toString() || "0")
-          )
-          .encodeABI();
         try {
+            const encodedTransferFunction = (await Utils.getTokenContract()).methods
+            .transfer(
+                transfer.address,
+                await Utils.toWei(transfer.amount.toString() || "0")
+            )
+            .encodeABI();
             const trxDetails = {
                 from: account,
                 to: process.env.REACT_APP_CONTRACTS_RIF_TOKEN,
@@ -210,7 +212,7 @@ function Transfer(props) {
                 <a href="#!" onClick={handleTransferSmartWalletButtonClick} className={`waves-effect waves-green btn-flat ${ loading? 'disabled' : ''}`}>
                     Transfer <img alt="loading" className={`loading ${ !loading? 'hide' : ''}`} src="images/loading.gif"/>
                 </a>
-                <a href="#!" id="deploy-smart-wallet-estimate" className={`waves-effect waves-green btn-flat ${estimateLoading ? "disabled" : ""}`}onClick={handleEstimateDeploySmartWalletButtonClick}>
+                <a href="#!" id="deploy-smart-wallet-estimate" className={`waves-effect waves-green btn-flat ${estimateLoading ? "disabled" : ""}`}onClick={handleEstimateTransferButtonClick}>
                     Estimate<img alt="loading" className={`loading ${!estimateLoading ? "hide" : ""}`} src="images/loading.gif"/>
                 </a>
                 <a href="#!" className="waves-effect waves-green btn-flat" onClick={() =>{


### PR DESCRIPTION
 Add the estimation button on the transfer modal. We decided to use the on-chain estimation, which requires that the user signs the transaction.
Fix other UI issues.

## What

- Add the estimation button
- Show the rbtc/trif switch on the transfer modal used to select the token to use to pay for the fees
- Fix estimate loading on deploy modal
- Fix the loading status that was shared between the estimate and execute buttons
- Fix the return data slide button in the execute modal

## Why 

- In order to identify how much transactions cost, the estimate button is added in the transfer modal. It was the only modal not having such functionality.
