### PR TITLE
PP-136: smart wallet transfer

### DIFF
--- a/src/contracts/IForwarder.json
+++ b/src/contracts/IForwarder.json
@@ -2,222 +2,222 @@
     "contractName": "IForwarder",
     "abi": [
         {
-          "inputs": [],
-          "name": "nonce",
-          "outputs": [
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "domainSeparator",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "bytes32",
-              "name": "suffixData",
-              "type": "bytes32"
-            },
-            {
-              "components": [
+            "inputs": [],
+            "name": "nonce",
+            "outputs": [
                 {
-                  "internalType": "address",
-                  "name": "relayHub",
-                  "type": "address"
-                },
-                {
-                  "internalType": "address",
-                  "name": "from",
-                  "type": "address"
-                },
-                {
-                  "internalType": "address",
-                  "name": "to",
-                  "type": "address"
-                },
-                {
-                  "internalType": "address",
-                  "name": "tokenContract",
-                  "type": "address"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "value",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "gas",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "nonce",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "tokenAmount",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "tokenGas",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "bytes",
-                  "name": "data",
-                  "type": "bytes"
+                    "internalType": "uint256",
+                    "name": "",
+                    "type": "uint256"
                 }
-              ],
-              "internalType": "struct IForwarder.ForwardRequest",
-              "name": "forwardRequest",
-              "type": "tuple"
-            },
-            {
-              "internalType": "bytes",
-              "name": "signature",
-              "type": "bytes"
-            }
-          ],
-          "name": "verify",
-          "outputs": [],
-          "stateMutability": "view",
-          "type": "function"
+            ],
+            "stateMutability": "view",
+            "type": "function"
         },
         {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "domainSeparator",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "bytes32",
-              "name": "suffixData",
-              "type": "bytes32"
-            },
-            {
-              "components": [
+            "inputs": [
                 {
-                  "internalType": "address",
-                  "name": "relayHub",
-                  "type": "address"
+                    "internalType": "bytes32",
+                    "name": "domainSeparator",
+                    "type": "bytes32"
                 },
                 {
-                  "internalType": "address",
-                  "name": "from",
-                  "type": "address"
+                    "internalType": "bytes32",
+                    "name": "suffixData",
+                    "type": "bytes32"
                 },
                 {
-                  "internalType": "address",
-                  "name": "to",
-                  "type": "address"
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "relayHub",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "from",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "to",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "tokenContract",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "value",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "gas",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "nonce",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenGas",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "data",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct IForwarder.ForwardRequest",
+                    "name": "forwardRequest",
+                    "type": "tuple"
                 },
                 {
-                  "internalType": "address",
-                  "name": "tokenContract",
-                  "type": "address"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "value",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "gas",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "nonce",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "tokenAmount",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "tokenGas",
-                  "type": "uint256"
-                },
-                {
-                  "internalType": "bytes",
-                  "name": "data",
-                  "type": "bytes"
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
                 }
-              ],
-              "internalType": "struct IForwarder.ForwardRequest",
-              "name": "forwardRequest",
-              "type": "tuple"
-            },
-            {
-              "internalType": "bytes",
-              "name": "signature",
-              "type": "bytes"
-            }
-          ],
-          "name": "execute",
-          "outputs": [
-            {
-              "internalType": "bool",
-              "name": "success",
-              "type": "bool"
-            },
-            {
-              "internalType": "bytes",
-              "name": "ret",
-              "type": "bytes"
-            }
-          ],
-          "stateMutability": "payable",
-          "type": "function"
+            ],
+            "name": "verify",
+            "outputs": [],
+            "stateMutability": "view",
+            "type": "function"
         },
         {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "to",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "value",
-              "type": "uint256"
-            },
-            {
-              "internalType": "bytes",
-              "name": "data",
-              "type": "bytes"
-            }
-          ],
-          "name": "directExecute",
-          "outputs": [
-            {
-              "internalType": "bool",
-              "name": "success",
-              "type": "bool"
-            },
-            {
-              "internalType": "bytes",
-              "name": "ret",
-              "type": "bytes"
-            }
-          ],
-          "stateMutability": "payable",
-          "type": "function"
+            "inputs": [
+                {
+                    "internalType": "bytes32",
+                    "name": "domainSeparator",
+                    "type": "bytes32"
+                },
+                {
+                    "internalType": "bytes32",
+                    "name": "suffixData",
+                    "type": "bytes32"
+                },
+                {
+                    "components": [
+                        {
+                            "internalType": "address",
+                            "name": "relayHub",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "from",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "to",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "address",
+                            "name": "tokenContract",
+                            "type": "address"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "value",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "gas",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "nonce",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenAmount",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "uint256",
+                            "name": "tokenGas",
+                            "type": "uint256"
+                        },
+                        {
+                            "internalType": "bytes",
+                            "name": "data",
+                            "type": "bytes"
+                        }
+                    ],
+                    "internalType": "struct IForwarder.ForwardRequest",
+                    "name": "forwardRequest",
+                    "type": "tuple"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "signature",
+                    "type": "bytes"
+                }
+            ],
+            "name": "execute",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "success",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "ret",
+                    "type": "bytes"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
+        },
+        {
+            "inputs": [
+                {
+                    "internalType": "address",
+                    "name": "to",
+                    "type": "address"
+                },
+                {
+                    "internalType": "uint256",
+                    "name": "value",
+                    "type": "uint256"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "data",
+                    "type": "bytes"
+                }
+            ],
+            "name": "directExecute",
+            "outputs": [
+                {
+                    "internalType": "bool",
+                    "name": "success",
+                    "type": "bool"
+                },
+                {
+                    "internalType": "bytes",
+                    "name": "ret",
+                    "type": "bytes"
+                }
+            ],
+            "stateMutability": "payable",
+            "type": "function"
         }
-      ]
+    ]
 }

--- a/src/contracts/IForwarder.json
+++ b/src/contracts/IForwarder.json
@@ -2,217 +2,222 @@
     "contractName": "IForwarder",
     "abi": [
         {
-            "inputs": [],
-            "name": "nonce",
-            "outputs": [
-                {
-                    "internalType": "uint256",
-                    "name": "",
-                    "type": "uint256"
-                }
-            ],
-            "stateMutability": "view",
-            "type": "function"
+          "inputs": [],
+          "name": "nonce",
+          "outputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function"
         },
         {
-            "inputs": [
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "domainSeparator",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "suffixData",
+              "type": "bytes32"
+            },
+            {
+              "components": [
                 {
-                    "internalType": "bytes32",
-                    "name": "domainSeparator",
-                    "type": "bytes32"
+                  "internalType": "address",
+                  "name": "relayHub",
+                  "type": "address"
                 },
                 {
-                    "internalType": "bytes32",
-                    "name": "suffixData",
-                    "type": "bytes32"
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
                 },
                 {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "relayHub",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "from",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "to",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "tokenContract",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "value",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "gas",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "nonce",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenAmount",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenGas",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "bytes",
-                            "name": "data",
-                            "type": "bytes"
-                        }
-                    ],
-                    "internalType": "struct IForwarder.ForwardRequest",
-                    "name": "forwardRequest",
-                    "type": "tuple"
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
                 },
                 {
-                    "internalType": "bytes",
-                    "name": "signature",
-                    "type": "bytes"
+                  "internalType": "address",
+                  "name": "tokenContract",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "value",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "gas",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "nonce",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenGas",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "data",
+                  "type": "bytes"
                 }
-            ],
-            "name": "verify",
-            "outputs": [],
-            "stateMutability": "view",
-            "type": "function"
+              ],
+              "internalType": "struct IForwarder.ForwardRequest",
+              "name": "forwardRequest",
+              "type": "tuple"
+            },
+            {
+              "internalType": "bytes",
+              "name": "signature",
+              "type": "bytes"
+            }
+          ],
+          "name": "verify",
+          "outputs": [],
+          "stateMutability": "view",
+          "type": "function"
         },
         {
-            "inputs": [
+          "inputs": [
+            {
+              "internalType": "bytes32",
+              "name": "domainSeparator",
+              "type": "bytes32"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "suffixData",
+              "type": "bytes32"
+            },
+            {
+              "components": [
                 {
-                    "internalType": "bytes32",
-                    "name": "domainSeparator",
-                    "type": "bytes32"
+                  "internalType": "address",
+                  "name": "relayHub",
+                  "type": "address"
                 },
                 {
-                    "internalType": "bytes32",
-                    "name": "suffixData",
-                    "type": "bytes32"
+                  "internalType": "address",
+                  "name": "from",
+                  "type": "address"
                 },
                 {
-                    "components": [
-                        {
-                            "internalType": "address",
-                            "name": "relayHub",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "from",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "to",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "address",
-                            "name": "tokenContract",
-                            "type": "address"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "value",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "gas",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "nonce",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenAmount",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "uint256",
-                            "name": "tokenGas",
-                            "type": "uint256"
-                        },
-                        {
-                            "internalType": "bytes",
-                            "name": "data",
-                            "type": "bytes"
-                        }
-                    ],
-                    "internalType": "struct IForwarder.ForwardRequest",
-                    "name": "forwardRequest",
-                    "type": "tuple"
+                  "internalType": "address",
+                  "name": "to",
+                  "type": "address"
                 },
                 {
-                    "internalType": "bytes",
-                    "name": "signature",
-                    "type": "bytes"
+                  "internalType": "address",
+                  "name": "tokenContract",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "value",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "gas",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "nonce",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenAmount",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "tokenGas",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "bytes",
+                  "name": "data",
+                  "type": "bytes"
                 }
-            ],
-            "name": "execute",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "success",
-                    "type": "bool"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "ret",
-                    "type": "bytes"
-                }
-            ],
-            "stateMutability": "payable",
-            "type": "function"
+              ],
+              "internalType": "struct IForwarder.ForwardRequest",
+              "name": "forwardRequest",
+              "type": "tuple"
+            },
+            {
+              "internalType": "bytes",
+              "name": "signature",
+              "type": "bytes"
+            }
+          ],
+          "name": "execute",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "ret",
+              "type": "bytes"
+            }
+          ],
+          "stateMutability": "payable",
+          "type": "function"
         },
         {
-            "inputs": [
-                {
-                    "internalType": "address",
-                    "name": "to",
-                    "type": "address"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "data",
-                    "type": "bytes"
-                }
-            ],
-            "name": "directExecute",
-            "outputs": [
-                {
-                    "internalType": "bool",
-                    "name": "success",
-                    "type": "bool"
-                },
-                {
-                    "internalType": "bytes",
-                    "name": "ret",
-                    "type": "bytes"
-                }
-            ],
-            "stateMutability": "payable",
-            "type": "function"
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "to",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "value",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes",
+              "name": "data",
+              "type": "bytes"
+            }
+          ],
+          "name": "directExecute",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "success",
+              "type": "bool"
+            },
+            {
+              "internalType": "bytes",
+              "name": "ret",
+              "type": "bytes"
+            }
+          ],
+          "stateMutability": "payable",
+          "type": "function"
         }
-    ]
+      ]
 }

--- a/src/modals/Execute.tsx
+++ b/src/modals/Execute.tsx
@@ -55,7 +55,8 @@ function Execute(props: ExecuteProps) {
 
     function calculateAbiEncodedFunction() {
         const contractFunction = execute.function.trim();
-        const functionSig = web3.eth.abi.encodeFunctionSignature(contractFunction);
+        const functionSig =
+            web3.eth.abi.encodeFunctionSignature(contractFunction);
 
         const paramsStart = contractFunction.indexOf('(', 0);
         const paramsEnd = contractFunction.indexOf(')', paramsStart);
@@ -91,30 +92,32 @@ function Execute(props: ExecuteProps) {
         swContract.setProvider(web3.currentProvider);
         const amount = execute.amount === '' ? '0' : execute.amount;
         const weiAmount = await Utils.toWei(amount);
-        await swContract.methods.directExecute(toAddress, weiAmount, abiEncodedTx).send(
-            {
-                from: account
-            },
-            // TODO: we may add the types
-            async (error: any, data: any) => {
-                if (error !== undefined && error !== null) {
-                    throw error;
-                } else {
-                    const txHash = data;
-                    console.log(`Your TxHash is ${txHash}`);
+        await swContract.methods
+            .directExecute(toAddress, weiAmount, abiEncodedTx)
+            .send(
+                {
+                    from: account
+                },
+                // TODO: we may add the types
+                async (error: any, data: any) => {
+                    if (error !== undefined && error !== null) {
+                        throw error;
+                    } else {
+                        const txHash = data;
+                        console.log(`Your TxHash is ${txHash}`);
 
-                    // checks to verify that the contract was executed properly
-                    const receipt = await Utils.getReceipt(txHash);
+                        // checks to verify that the contract was executed properly
+                        const receipt = await Utils.getReceipt(txHash);
 
-                    console.log(`Your receipt is`);
-                    console.log(receipt);
+                        console.log(`Your receipt is`);
+                        console.log(receipt);
 
-                    const trxData = await web3.eth.getTransaction(txHash);
-                    console.log('Your tx data is');
-                    console.log(trxData);
+                        const trxData = await web3.eth.getTransaction(txHash);
+                        console.log('Your tx data is');
+                        console.log(trxData);
+                    }
                 }
-            }
-        );
+            );
     }
 
     function close() {
@@ -145,8 +148,6 @@ function Execute(props: ExecuteProps) {
                 const funcData = calculateAbiEncodedFunction();
                 const destinationContract = execute.address;
                 const swAddress = currentSmartWallet.address;
-
-
 
                 if (execute.check) {
                     await relayTransactionDirectExecution(
@@ -484,9 +485,11 @@ function Execute(props: ExecuteProps) {
                             </div>
                         </div>
                         <div className='row mb-0'>
-                            <div className={`input-field col s8 ${
-                                execute.check ? '' : 'hide'
-                            }`}>
+                            <div
+                                className={`input-field col s8 ${
+                                    execute.check ? '' : 'hide'
+                                }`}
+                            >
                                 <input
                                     placeholder='0'
                                     id='execute-param-values'

--- a/src/modals/Execute.tsx
+++ b/src/modals/Execute.tsx
@@ -460,7 +460,9 @@ function Execute(props: ExecuteProps) {
                                     htmlFor='execute-fees'
                                     id='execute-fees-label'
                                 >
-                                    {execute.check ? 'Amount to be sent' : 'Fees (tRIF)'}
+                                    {execute.check
+                                        ? 'Amount to be sent'
+                                        : 'Fees (tRIF)'}
                                 </label>
                             </div>
                             <div

--- a/src/modals/Execute.tsx
+++ b/src/modals/Execute.tsx
@@ -33,7 +33,6 @@ type ExecuteInfo = {
     address: string;
     value: string;
     function: string;
-    amount: string;
 };
 
 type ExecuteInfoKey = keyof ExecuteInfo;
@@ -47,8 +46,7 @@ function Execute(props: ExecuteProps) {
         address: '',
         value: '',
         function: '',
-        fees: '',
-        amount: ''
+        fees: ''
     });
     const [executeLoading, setExecuteLoading] = useState(false);
     const [estimateLoading, setEstimateLoading] = useState(false);
@@ -90,9 +88,9 @@ function Execute(props: ExecuteProps) {
     ) {
         const swContract = new web3.eth.Contract(IForwarder.abi, swAddress);
         swContract.setProvider(web3.currentProvider);
-        const amount = execute.amount === '' ? '0' : execute.amount;
-        const weiAmount = await Utils.toWei(amount);
-        await swContract.methods
+        const fees = execute.fees === '' ? '0' : execute.fees;
+        const weiAmount = await Utils.toWei(fees.toString());
+        const transaction = await swContract.methods
             .directExecute(toAddress, weiAmount, abiEncodedTx)
             .send(
                 {
@@ -115,6 +113,9 @@ function Execute(props: ExecuteProps) {
                         const trxData = await web3.eth.getTransaction(txHash);
                         console.log('Your tx data is');
                         console.log(trxData);
+                        if (execute.show) {
+                            setResults(JSON.stringify(transaction));
+                        }
                     }
                 }
             );
@@ -129,8 +130,7 @@ function Execute(props: ExecuteProps) {
             address: '',
             value: '',
             function: '',
-            fees: '',
-            amount: ''
+            fees: ''
         });
     }
 
@@ -207,8 +207,8 @@ function Execute(props: ExecuteProps) {
     ) {
         const swContract = new web3.eth.Contract(IForwarder.abi, swAddress);
         swContract.setProvider(web3.currentProvider);
-        const amount = execute.amount === '' ? '0' : execute.amount;
-        const weiAmount = await Utils.toWei(amount);
+        const fees = execute.fees === '' ? '0' : execute.fees;
+        const weiAmount = await Utils.toWei(fees.toString());
         const estimate = await swContract.methods
             .directExecute(toAddress, weiAmount, abiEncodedTx)
             .estimateGas({ from: account });
@@ -460,7 +460,7 @@ function Execute(props: ExecuteProps) {
                                     htmlFor='execute-fees'
                                     id='execute-fees-label'
                                 >
-                                    Fees (tRIF)
+                                    {execute.check ? 'Amount to be sent' : 'Fees (tRIF)'}
                                 </label>
                             </div>
                             <div
@@ -481,30 +481,6 @@ function Execute(props: ExecuteProps) {
                                     />
                                     <span className='lever' />
                                     RBTC
-                                </label>
-                            </div>
-                        </div>
-                        <div className='row mb-0'>
-                            <div
-                                className={`input-field col s8 ${
-                                    execute.check ? '' : 'hide'
-                                }`}
-                            >
-                                <input
-                                    placeholder='0'
-                                    id='execute-param-values'
-                                    type='text'
-                                    className='validate'
-                                    onChange={(event) => {
-                                        changeValue(
-                                            event.currentTarget.value,
-                                            'amount'
-                                        );
-                                    }}
-                                    value={execute.amount}
-                                />
-                                <label htmlFor='execute-param-values'>
-                                    Amount to be sent
                                 </label>
                             </div>
                         </div>


### PR DESCRIPTION
## What

Removed the process where native cryptocurrency balance is transferred back to the owner EOA

## Why

It would be more consistent (simpler, in UX terms) to leave the native cryptocurrency balance in the SmartWallet instead of transferring it to the owner EOA after each execution.

## Refs

- [Jira issue](https://github.com/rsksmart/rif-relay/issues/179)