### PR TITLE
fix(pub): uses relay deps that build on install

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1-alpha.1",
   "private": true,
   "dependencies": {
-    "@rsksmart/rif-relay-client": "0.0.2-alpha.2",
-    "@rsksmart/rif-relay-common": "0.0.2-alpha.3",
-    "@rsksmart/rif-relay-sdk": "^0.0.1-alpha.4",
+    "@rsksmart/rif-relay-client": "0.0.2-alpha.3",
+    "@rsksmart/rif-relay-common": "0.0.2-alpha.4",
+    "@rsksmart/rif-relay-sdk": "^0.0.1-alpha.5",
     "@rsksmart/rlogin": "^1.4.0-beta.1",
     "@testing-library/jest-dom": "^5.11.4",
     "@testing-library/react": "^11.1.0",


### PR DESCRIPTION
## What

-   updates rif relay dependencies to versions that build upon install

## Why

-   to allow automatic build for development and production

## Refs

- relates to https://rsklabs.atlassian.net/browse/PP-166
- source: https://www.npmjs.com/package/npmignore
