### PR TITLE
PP-653: fix continuous deployment

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -2,7 +2,7 @@ name: QA CD
 
 on:
   push:
-    branches: [dev]
+    branches: [main]
 
 jobs:
   deploy:


### PR DESCRIPTION
## What

- Change the branch used to deploy to QA

## Why

- For consistency with the other repos, we set `main` as the default branch