### PR TITLE
fix: wait for transaction receipt on SW deployment

### DIFF
--- a/src/modals/Deploy.tsx
+++ b/src/modals/Deploy.tsx
@@ -18,6 +18,8 @@ type DeployInfo = {
 
 type DeployInfoKey = keyof DeployInfo;
 
+const FORTY_SECONDS = 40 * 1000;
+
 function Deploy() {
   const { state, dispatch } = useStore();
   const {
@@ -87,7 +89,7 @@ function Deploy() {
     if ( !provider ) {
       return false;
     }
-    const receipt = await provider.waitForTransaction(txHash, 1, 40000);
+    const receipt = await provider.waitForTransaction(txHash, 1, FORTY_SECONDS);
     if (receipt === null) {
       return false;
     }

--- a/src/modals/Deploy.tsx
+++ b/src/modals/Deploy.tsx
@@ -84,7 +84,10 @@ function Deploy() {
   };
 
   const checkSmartWalletDeployment = async (txHash: string) => {
-    const receipt = await provider!.getTransactionReceipt(txHash);
+    if ( !provider ) {
+      return false;
+    }
+    const receipt = await provider.waitForTransaction(txHash, 1, 40000);
     if (receipt === null) {
       return false;
     }

--- a/src/modals/Deploy.tsx
+++ b/src/modals/Deploy.tsx
@@ -86,7 +86,7 @@ function Deploy() {
   };
 
   const checkSmartWalletDeployment = async (txHash: string) => {
-    if ( !provider ) {
+    if (!provider) {
       return false;
     }
     const receipt = await provider.waitForTransaction(txHash, 1, FORTY_SECONDS);


### PR DESCRIPTION
## What

- after requesting the server to relay a SW deployment, wait for the transaction receipt

## Why

- because right now the dapp shows a message that the SW failed, while the tx receipt isn't ready yet.