### PR TITLE
Fix: Testnet deployment

### DIFF
--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        npm ci
+        npm ci --force # FIXME: PP-648
 
     - name: Build site
       run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rif-relay-sample-dapp",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rif-relay-sample-dapp",
-      "version": "2.0.0-beta.1",
+      "version": "2.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@rsksmart/rif-relay-client": "2.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-sample-dapp",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "private": true,
   "description": "This project contains a sample dApp to interact with the RIF Relay project.",
   "keywords": [


### PR DESCRIPTION
## What

- force the installation of the dependencies

## Why

- because it's required after the latest upgrade of the libraries (we already tracked this with a task)

(Ref [PP-648](https://rsklabs.atlassian.net/browse/PP-648))