### PR TITLE
PP-779: use the latest version of the rif-relay-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
-        "@rsksmart/rif-relay-client": "2.0.0-beta.7",
+        "@rsksmart/rif-relay-client": "2.0.0",
         "@rsksmart/rif-relay-contracts": "2.0.0-beta.1",
         "@rsksmart/rlogin": "^1.4.1-beta.1",
         "@testing-library/jest-dom": "^5.16.5",
@@ -4593,9 +4593,9 @@
       }
     },
     "node_modules/@rsksmart/rif-relay-client": {
-      "version": "2.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.0.0-beta.7.tgz",
-      "integrity": "sha512-pMWnUpuvuKttQz4zVtF+q5yA2ubfglB39KahLqdiUq6S2i1zTCkl1Nv6Cc8weGexQBv3OC3nZ/8yrsncAbN22w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.0.0.tgz",
+      "integrity": "sha512-9lgRf6Q4tCoy3rCVeyqx/0ZN406SyM2gePsPd76ricj5IVKGboj8XpBjf/mPLogoEXVcOsHZ4O28P+tU9HuofA==",
       "dependencies": {
         "bignumber.js": "^9.1.1",
         "loglevel": "~1.8.0",
@@ -27386,9 +27386,9 @@
       }
     },
     "@rsksmart/rif-relay-client": {
-      "version": "2.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.0.0-beta.7.tgz",
-      "integrity": "sha512-pMWnUpuvuKttQz4zVtF+q5yA2ubfglB39KahLqdiUq6S2i1zTCkl1Nv6Cc8weGexQBv3OC3nZ/8yrsncAbN22w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rsksmart/rif-relay-client/-/rif-relay-client-2.0.0.tgz",
+      "integrity": "sha512-9lgRf6Q4tCoy3rCVeyqx/0ZN406SyM2gePsPd76ricj5IVKGboj8XpBjf/mPLogoEXVcOsHZ4O28P+tU9HuofA==",
       "requires": {
         "bignumber.js": "^9.1.1",
         "loglevel": "~1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rsksmart/rif-relay-sample-dapp",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@rsksmart/rif-relay-sample-dapp",
-      "version": "2.0.0-beta.2",
+      "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
         "@rsksmart/rif-relay-client": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rsksmart/rif-relay-sample-dapp",
-  "version": "2.0.0-beta.2",
+  "version": "2.0.0",
   "private": true,
   "description": "This project contains a sample dApp to interact with the RIF Relay project.",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     ]
   },
   "dependencies": {
-    "@rsksmart/rif-relay-client": "2.0.0-beta.7",
+    "@rsksmart/rif-relay-client": "2.0.0",
     "@rsksmart/rif-relay-contracts": "2.0.0-beta.1",
     "@rsksmart/rlogin": "^1.4.1-beta.1",
     "@testing-library/jest-dom": "^5.16.5",


### PR DESCRIPTION
## What

- Update rif-relay-client to the latest version

## Why

- It includes the exchange apis cache.