### PR TITLE
update to use iam roles (oidc), no longer access keys

### DIFF
--- a/.github/workflows/deploy-qa.yml
+++ b/.github/workflows/deploy-qa.yml
@@ -14,10 +14,9 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.QA_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.QA_AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.QA_ROLE_ARN }}
         aws-region: ${{ secrets.QA_AWS_REGION }}
 
     - name: Setup Node 16

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -15,11 +15,10 @@ jobs:
       uses: actions/checkout@v2
     
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v1
+      uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.TESTNET_AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.TESTNET_AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.TESTNET_AWS_REGION }}
+        role-to-assume: ${{ secrets.TESTNET_ROLE_ARN }}
+        aws-region: ${{ secrets.TESTNET_AWS_REGION }}}
 
     - name: Setup Node 16
       uses: actions/setup-node@v1


### PR DESCRIPTION
## What

-  We no longer use aws access and secret keys in CICD

## Why

-   Security Reasons, It's safer to use ROLES which are attached and can only be used with it's assigned repository.

## Refs

-   OKR goals https://github.com/rootstock/iac-ng/pull/1269/files
